### PR TITLE
Fix issue #11

### DIFF
--- a/lib/chrome_api.dart
+++ b/lib/chrome_api.dart
@@ -115,6 +115,7 @@ class TabsQueryInfo {
 
   external String? get title;
   external String? get url;
+  external String? get windowType;
 
   external factory TabsQueryInfo({
     bool? active,
@@ -125,6 +126,7 @@ class TabsQueryInfo {
     int? windowId,
     String? title,
     String? url,
+    String? windowType,
   });
 }
 

--- a/lib/providers/category_info_provider.dart
+++ b/lib/providers/category_info_provider.dart
@@ -49,7 +49,7 @@ class CategoryInfoNotifier extends StateNotifier<AsyncValue<CategoryInfo>> {
       final Map<String, List<String>> results =
           response.data!.map((k, v) => MapEntry(k, v));
 
-      late final int unclassified;
+      int unclassified = -1;
 
       // Fill Category field to each Url
       for (var entry in results.entries) {
@@ -72,7 +72,9 @@ class CategoryInfoNotifier extends StateNotifier<AsyncValue<CategoryInfo>> {
           unclassified = groupId;
         }
       }
-      await moveTabGroups(unclassified, TabGroupsMoveProperties(index: -1));
+      if (unclassified != -1) {
+        await moveTabGroups(unclassified, TabGroupsMoveProperties(index: -1));
+      }
       await fetchTabs();
     } catch (err, stack) {
       state = AsyncValue.error(err, stack);

--- a/lib/providers/category_info_provider.dart
+++ b/lib/providers/category_info_provider.dart
@@ -19,7 +19,9 @@ class CategoryInfoNotifier extends StateNotifier<AsyncValue<CategoryInfo>> {
 
   Future<void> fetchTabs() async {
     state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => queryTabs(TabsQueryInfo()));
+    state = await AsyncValue.guard(() => queryTabs(
+          TabsQueryInfo(windowType: 'normal'),
+        ));
   }
 
   Future<void> classify() async {

--- a/lib/screens/popup_screen.dart
+++ b/lib/screens/popup_screen.dart
@@ -26,7 +26,7 @@ class PopupScreen extends HookConsumerWidget {
           loading: () => const LoadingScreen(),
           error: (error, _) => Scaffold(
             body: Center(
-              child: Text(
+              child: SelectableText(
                 error.toString(),
               ),
             ),

--- a/web/chrome_api.js
+++ b/web/chrome_api.js
@@ -1,5 +1,6 @@
 async function queryTabs(options) {
     let tabs = await chrome.tabs.query(options);
+
     let data = tabs.map(tab => {
         return {
             active: tab.active,


### PR DESCRIPTION
Fix #11 
`Unclassified`と分類されるタブが一つもないとおきるバグをとりました

また、`WindowType`が`normal`でないタブは移動することができないため、`queryTabs`の時点で`windowType: 'normal'`として、`normal`な`Window`に含まれるタブのみを分類、整理する仕様にしました