### PR TITLE
Remove dotenv & Update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Tabooo
 開いているChromeタブをトピック分類して自動で整理してくれるアプリです。
 
-## 使い方(開発版)
-1. 以下のオプションを付けてビルド
-  `flutter build web --web-renderer html --csp`
-2. `build/web`を拡張機能として読み込む
-3. 右上の拡張機能アイコンをクリック
-4. 自動整理ボタンを押下してタブ整理
+## ビルドする方法
+1. `git clone git@github.com:payashi/tabooo-client.git`
+2. `cd tabooo-client`
+3. `flutter build web --web-renderer html --csp`
 
 ## 使用しているアイコンについて
 無料イラスト素材サイト[ぴよたそ](https://hiyokoyarou.com/chatora-osuwari/)よりお借りしています

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tab_organizer/screens/popup_screen.dart';
 
 void main() async {
-  await dotenv.load();
   runApp(
     const ProviderScope(
       child: MaterialApp(

--- a/lib/providers/category_info_provider.dart
+++ b/lib/providers/category_info_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:js_interop';
 
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:tab_organizer/chrome_api.dart';
 import 'package:tab_organizer/models/category_info.dart';
 import 'package:tab_organizer/models/chrome_tab.dart';
@@ -8,7 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:dio/dio.dart';
 
-final apiUrl = dotenv.get('API_BASE_URL');
+const apiUrl = "https://tabooo-api-s2tocqio2a-an.a.run.app";
 
 class CategoryInfoNotifier extends StateNotifier<AsyncValue<CategoryInfo>> {
   static final dio = Dio();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,14 +214,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_dotenv:
-    dependency: "direct main"
-    description:
-      name: flutter_dotenv
-      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
   flutter_hooks:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   js: ^0.6.7
   freezed_annotation: ^2.4.1
   dio: ^5.3.2
-  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -32,6 +31,5 @@ flutter:
   uses-material-design: true
 
   assets:
-    - .env
     - assets/tabby.png
     - assets/engineer.png

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Tabooo",
     "description": "開いているChromeタブをトピック分類して自動で整理してくれるアプリです。",
     "content_security_policy": {
@@ -24,8 +24,5 @@
     "permissions": [
         "tabs",
         "tabGroups"
-    ],
-    "host_permissions": [
-        "https://tabooo-api-s2tocqio2a-an.a.run.app/*"
     ]
 }


### PR DESCRIPTION
- `README.md`を改善しました
- Chrome Web Storeにあげると`.env`がなくなってしまうみたいなので`dotenv`関連のコードを書き換えました。
  (もともと`.env`で管理していたAPI Tokenとかはありません)
- `manifest.json`で不要な`host_permissions`を削除しました
- `manifest.json`でバージョン番号を更新、ストアにアップロードしました